### PR TITLE
fix version compare

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,16 @@ Changelog
 `Unreleased <http://github.com/plstcharles/thelper/tree/master>`_ (latest)
 ----------------------------------------------------------------------------------
 
+* Fix version comparison check when validating configuration and/or checkpoint against package version.
+  Version can now have a release part which was not considered.
+
 `0.5.0-rc <http://github.com/plstcharles/thelper/tree/0.5.0-rc>`_ (%Y/%m/%d)
 ----------------------------------------------------------------------------------
 
 * Update this changelog to use rst links (renders on github and readthedocs)
 * Add ``infer`` mode for classification of geo-referenced rasters
 * Add ``Dockerfile-geo`` to build thelper with pre-installed geo packages
-* Add geo-related build instructions to travis-ci build steps 
+* Add geo-related build instructions to travis-ci build steps
 * Add auto-documentation of makefile targets and docker related targets
 
 `0.4.7 <http://github.com/plstcharles/thelper/tree/0.4.7>`_ (2019/11/20)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -58,3 +58,24 @@ def test_load_checkpoint_not_default_cpu_with_devices(mock_torch_load, mock_thel
     checkpoint_file = 'dummy-checkpoint.pth'
     thelper.utils.load_checkpoint(checkpoint_file)
     mock_torch_load.assert_called_once_with(checkpoint_file, map_location=None)
+
+
+def test_check_version_correct_parsing_and_not_future():
+    versions_tests = [
+        # not-future, check, required, expected check parts, expected required parts
+        ("0.1.0", "0.2.0", True, [0, 1, 0, ''], [0, 2, 0]),
+        ("0.2.0", "0.2.1", True, [0, 2, 0, ''], [0, 2, 1]),
+        ("0.3.1", "0.2.2", False, [0, 3, 1, ''], [0, 2, 2]),
+        ("0.4.8", "0.5.0-rc", True, [0, 4, 8, ''], [0, 5, 0, 'rc']),
+        ("0.5.0a0", "0.5.0-rc", True, [0, 5, 0, 'a0'], [0, 5, 0, 'rc'])  # invalid parsing of '-' switches result around
+    ]
+    for i, ver_test in enumerate(versions_tests):
+        ver_check, ver_req, exp_ver_ok, exp_ver_check, exp_ver_req = ver_test
+        res_ver_ok, res_ver_check, res_ver_req = thelper.utils.check_version(ver_check, ver_req)
+        assert res_ver_ok == exp_ver_ok, f"supposed to get {exp_ver_ok} for [{ver_check}] and [{ver_req}] (test: {i})"
+        assert len(res_ver_check) == 4, "missing parts in parsing result"
+        assert len(res_ver_req) == 4, "missing parts in parsing result"
+        assert all(list(rv == ev for rv, ev in zip(res_ver_check, exp_ver_check))), \
+            f"check version parsing mismatches the expected result ({res_ver_check} != {exp_ver_check}) (test: {i})"
+        assert all(list(rv == ev for rv, ev in zip(res_ver_req, exp_ver_req))), \
+            f"required version parsing mismatches the expected result ({res_ver_req} != {exp_ver_req}) (test: {i})"

--- a/thelper/utils.py
+++ b/thelper/utils.py
@@ -264,13 +264,11 @@ def check_version(version_check, version_required):
     """Verifies that the checked version is not greater than the required one (ie: not a future version).
 
     Version format is ``MAJOR[.MINOR[.PATCH[[-]<RELEASE>]]]``.
-    Some valid example versions:
-
 
     Note that for ``RELEASE`` part, comparison depends on alphabetical order if all other previous parts were equal
     (i.e.: ``alpha`` will be lower than ``beta``, which in turn is lower than ``rc`` and so on). The ``-`` is optional
     and will be removed for comparison (i.e.: ``0.5.0-rc`` is exactly the same as ``0.5.0rc`` and the additional ``-``
-    will not result in evaluating ``0.5.0a0`` as a smaller version).
+    will not result in evaluating ``0.5.0a0`` as a greater version because of ``-`` being lower ascii than ``a``).
 
     Args:
         version_check: the version string that needs to be verified and compared for lower than the required version.


### PR DESCRIPTION
- fix version `0.5.0-rc` causing migration script to break because of new release part
- add method for version comparison normalizing it to 4 params
- add unittest validating the new method with a few use cases