### PR TITLE
patch metrics & concepts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ----------------------------------------------------------------------------------
 
 * Skip image save call during metric rendering if the provided value is ``None`` as employed by basic logger/reporter.
+* Add JSON implementation for ``thelper.train.utils.ClassifLogger``.
 * Fix ``concepts`` to handle any variation of upper/lower concept name.
 
 `0.5.0-rc2 <http://github.com/plstcharles/thelper/tree/v0.5.0-rc2>`_ (2020/07/08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 `Unreleased <http://github.com/plstcharles/thelper/tree/master>`_ (latest)
 ----------------------------------------------------------------------------------
 
-.. **INSERT APPLIED CHANGES HERE**
+* Skip image save call during metric rendering if the provided value is ``None`` as employed by basic logger/reporter.
+* Fix ``concepts`` to handle any variation of upper/lower concept name.
 
 `0.5.0-rc2 <http://github.com/plstcharles/thelper/tree/v0.5.0-rc2>`_ (2020/07/08)
 ----------------------------------------------------------------------------------

--- a/tests/concepts/test_support.py
+++ b/tests/concepts/test_support.py
@@ -99,3 +99,19 @@ def test_class_decorated_with_helper_without_parenthesis():
     assert thelper.concepts.supports(t2, "test2")
     assert thelper.concepts.supports(t3, "test1")
     assert not thelper.concepts.supports(t3, "test2")
+
+
+def test_concept_any_capitalization():
+
+    @thelper.concepts.apply_support(concept="test1")
+    class Test1(object):
+        pass
+
+    t1 = Test1()
+
+    for concept in ["test1", "TEST1", "Test1"]:
+        assert thelper.concepts.supports(Test1, concept)
+        assert thelper.concepts.supports(t1, concept)
+    for concept in ["test2", "TEST2", "Test2"]:
+        assert not thelper.concepts.supports(Test1, concept)
+        assert not thelper.concepts.supports(t1, concept)

--- a/thelper/concepts.py
+++ b/thelper/concepts.py
@@ -81,7 +81,10 @@ def supports(thing, concept):
         | :func:`thelper.concepts.segmentation`
         | :func:`thelper.concepts.regression`
     """
-    return getattr(thing, f"{SUPPORT_PREFIX}{concept}", False) if isinstance(concept, str) else False
+    if not isinstance(concept, str):
+        return False
+    concept = concept.lower()  # in case it was capitalized
+    return getattr(thing, f"{SUPPORT_PREFIX}{concept}", False)
 
 
 def classification(func_or_cls=None):

--- a/thelper/session/base.py
+++ b/thelper/session/base.py
@@ -431,7 +431,7 @@ class SessionRunner:
                         writer.add_text(f"{writer_prefix}{key}", val, idx)
                     else:
                         writer.add_scalar(f"{writer_prefix}{key}", val, idx)
-            if key.endswith("/image"):
+            if key.endswith("/image") and val is not None:  # some metrics got the callable but return None
                 assert isinstance(val, np.ndarray) and len(val.shape) == 3 and val.shape[2] == 3, \
                     "unexpected image format (should be numpy array with RGB channels)"
                 image_ext = thelper.utils.get_key_def(key + "/extension", data, "png")

--- a/thelper/train/utils.py
+++ b/thelper/train/utils.py
@@ -219,6 +219,18 @@ class ClassifLogger(PredictionConsumer, ClassNamesHandler, FormatHandler):
         # type: () -> Optional[AnyStr]
         return self.report_csv()
 
+    def report_json(self):
+        # type: () -> Optional[AnyStr]
+        csv = self.report_csv()
+        if csv is None:
+            return None
+        csv = csv.splitlines()
+        header, data = csv[0], csv[1:]
+        headers = header.split(",")
+        json_entries = [{k: float(v) if "score" in k else str(v)
+                         for k, v in zip(headers, line.split(","))} for line in data]
+        return json.dumps(json_entries, sort_keys=False, indent=4)
+
     def report_csv(self):
         # type: () -> Optional[AnyStr]
         """Returns the logged metadata of predicted samples.


### PR DESCRIPTION
When calling for example `ClassifReport` or `ClassifLogger`, the "image" was set to None which raised immediately during the numpy assert, but this kind of metrics make sense to not have any image, although they still could if we wanted to (eg: in Segmentation context).

I would tag `0.5.0` after this. 