### PR TITLE
add missing hdf5plugin requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gitpython
 h5py
+hdf5plugin
 kornia
 lz4
 matplotlib


### PR DESCRIPTION
Not too sure why, but 0.6+ versions fresh install fails with missing `hdf5plugin` dependency.