### PR TITLE
add SelectChannel transform

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 `Unreleased <http://github.com/plstcharles/thelper/tree/master>`_ (latest)
 ----------------------------------------------------------------------------------
 
-.. **INSERT APPLIED CHANGES HERE**
+* Added ``SelectChannels`` transform operator for inplace sample modifications that might need it.
 
 `0.6.1 <http://github.com/plstcharles/thelper/tree/v0.6.1>`_ (2020/07/29)
 ----------------------------------------------------------------------------------

--- a/thelper/transforms/__init__.py
+++ b/thelper/transforms/__init__.py
@@ -20,6 +20,7 @@ from thelper.transforms.operations import NoTransform  # noqa: F401
 from thelper.transforms.operations import RandomResizedCrop  # noqa: F401
 from thelper.transforms.operations import RandomShift  # noqa: F401
 from thelper.transforms.operations import Resize  # noqa: F401
+from thelper.transforms.operations import SelectChannels  # noqa: F401
 from thelper.transforms.operations import Tile  # noqa: F401
 from thelper.transforms.operations import ToColor  # noqa: F401
 from thelper.transforms.operations import ToGray  # noqa: F401

--- a/thelper/transforms/operations.py
+++ b/thelper/transforms/operations.py
@@ -162,7 +162,7 @@ class SelectChannels:
             f"source channel indices ({list(self.channels)}) " \
             f"cannot be greater than the number of available channels ({n_from_channels})"
         inv_map = {v: k for k, v in self.channels.items()}  # guaranteed 0..N keys with init checks
-        sample = np.dstack(sample[:, :, inv_map[i]] for i in range(n_to_channels))
+        sample = np.dstack([sample[:, :, inv_map[i]] for i in range(n_to_channels)])
         if n_to_channels == 1:
             return sample[:, :, 0]  # force cast to have expected format HxWx1
         return sample


### PR DESCRIPTION
utility transform can be used to convert samples with subset and/or reordered channels from originals defined by a dataset